### PR TITLE
Changed DB dump to not lock tables

### DIFF
--- a/cloudvps-boss/pre-backup.d/15-mysql_backup.sh
+++ b/cloudvps-boss/pre-backup.d/15-mysql_backup.sh
@@ -190,7 +190,7 @@ rm /var/backups/sql/*.sql.gz # verwijder de oude sql backups
 
 for DB in ${DATABASES}; do
     lecho "Dumping database ${DB} to /var/backups/sql/${DB}.sql.gz"
-    ionice -c2 nice -n19 mysqldump --opt --lock-all-tables --quick --hex-blob --force "${DB}" | ionice -c2 nice -n19 gzip > "/var/backups/sql/${DB}.sql.gz"
+    ionice -c2 nice -n19 mysqldump --opt --single-transaction --quick --hex-blob --force --skip-lock-tables "${DB}" | ionice -c2 nice -n19 gzip > "/var/backups/sql/${DB}.sql.gz"
     if [[ $? -ne 0 ]]; then
         lerror "Database dump ${DB} failed."
     else


### PR DESCRIPTION
Locking tables during the backup process will cause other queries to backup. This slows down the website or can result in the website not being available all together. Changed this behaviour to not lock tables during the backup process.