### PR TITLE
Fix to get cloudvps-boss-cleanup to work

### DIFF
--- a/cloudvps-boss/cloudvps-boss-cleanup.sh
+++ b/cloudvps-boss/cloudvps-boss-cleanup.sh
@@ -32,7 +32,7 @@ source /etc/cloudvps-boss/common.sh
 
 lecho "${TITLE} started on ${HOSTNAME} at $(date)."
 
-lecho "duplicity cleanup --extra-clean --force ${BACKUP_BACKEND}"
+lecho "duplicity cleanup --file-prefix="${HOSTNAME}." --name="${HOSTNAME}." --extra-clean --force ${BACKUP_BACKEND}"
 
 OLD_IFS="${IFS}"
 IFS=$'\n'

--- a/cloudvps-boss/cloudvps-boss-cleanup.sh
+++ b/cloudvps-boss/cloudvps-boss-cleanup.sh
@@ -38,6 +38,8 @@ OLD_IFS="${IFS}"
 IFS=$'\n'
 DUPLICITY_OUTPUT=$(duplicity \
     cleanup \
+    --file-prefix="${HOSTNAME}." \
+    --name="${HOSTNAME}." \
     --extra-clean \
     --force \
     ${ENCRYPTION_OPTIONS} \

--- a/install.sh
+++ b/install.sh
@@ -342,7 +342,7 @@ if [[ ! -d "/usr/local/bin" ]]; then
     mkdir -p "/usr/local/bin"
 fi
 
-for COMMAND in "cloudvps-boss.sh" "cloudvps-boss-restore.sh" "cloudvps-boss-stats.sh" "cloudvps-boss-update.sh" "cloudvps-boss-list-current-files.sh" "cloudvps-boss-manual-full.sh"; do
+for COMMAND in "cloudvps-boss.sh" "cloudvps-boss-cleanup.sh" "cloudvps-boss-restore.sh" "cloudvps-boss-stats.sh" "cloudvps-boss-update.sh" "cloudvps-boss-list-current-files.sh" "cloudvps-boss-manual-full.sh"; do
     log "Creating symlink for /etc/cloudvps-boss/${COMMAND} in /usr/local/bin/${COMMAND%.sh}."
     chmod +x "/etc/cloudvps-boss/${COMMAND}"
     ln -fs "/etc/cloudvps-boss/${COMMAND}" "/usr/local/bin/${COMMAND%.sh}"


### PR DESCRIPTION
**Description**

The cloudvps-boss-cleanup command is a wrapper around the duplicity cleanup command which can be used to cleanup incomplete backup chains. This script was not working so this PR addresses the issues in this script so that the cleanup script can actually be used. 

**What has been done**

- Changed installation so that script will be executable and is symlinked from the /usr/local/bin directory
- Changed cleanup configuration so that it will actually cleanup things

**Test scenario**

Running the following command will actually cleanup files from the objectstore which are not longer in a backup chain:
```
cloudvps-boss-cleanup
```