### PR TITLE
Fixed running update script once a month

### DIFF
--- a/cloudvps-boss/cloudvps-boss.cron
+++ b/cloudvps-boss/cloudvps-boss.cron
@@ -24,3 +24,5 @@ MAILTO="root"
 # CloudVPS Boss Backup
 1 1 * * * root /usr/local/bin/cloudvps-boss
 
+# CloudVPS Boss Update
+0 1 1 * * root /usr/local/bin/cloudvps-boss-update


### PR DESCRIPTION
Fix for running the update script again. This was somehow removed so it will not update to the most recent version anymore.

Please note documentation still mentions update script is run once a month, unfortunately it's not anymore. This PR fixes this issue. However, since no auto update is being executed, on existing servers it will need to be executed manually in order to update to the version with this PR included in order to execute it automatically again.