### PR TITLE
Fixed fetching IP address in error message mails

### DIFF
--- a/cloudvps-boss/post-fail-backup.d/20-failure-notify.sh
+++ b/cloudvps-boss/post-fail-backup.d/20-failure-notify.sh
@@ -57,7 +57,7 @@ getlogging() {
 
 errormail() {
 
-    mail -s "[CLOUDVPS BOSS] ${HOSTNAME}/$(curl -s http://ip.raymii.org): Critical error occurred during the backup!" "${recipient}" <<MAIL
+    mail -s "[CLOUDVPS BOSS] ${HOSTNAME}/$(curl -s http://ip.cloudvps.nl): Critical error occurred during the backup!" "${recipient}" <<MAIL
 
 Dear user,
 
@@ -74,7 +74,7 @@ $(cloudvps-boss-stats)
 $(getlogging)
 ===== END CLOUDVPS BOSS ERROR LOG =====
 
-This is server $(curl -s http://ip.raymii.org). You are using CloudVPS Boss ${VERSION}
+This is server $(curl -s http://ip.cloudvps.nl). You are using CloudVPS Boss ${VERSION}
 to backup files to the CloudVPS Object Store.
 
 Your files have not been backupped at this time. Please investigate this issue.

--- a/cloudvps-boss/pre-backup.d/11_lockfile_check.sh
+++ b/cloudvps-boss/pre-backup.d/11_lockfile_check.sh
@@ -34,7 +34,7 @@ greater_than_24hour_mail() {
         command_exists "${COMMAND}"
     done
 
-    mail -s "[CLOUDVPS BOSS] ${HOSTNAME}/$(curl -s http://ip.raymii.org): Other backup job still running, more than 24 hours." "${recipient}" <<MAIL
+    mail -s "[CLOUDVPS BOSS] ${HOSTNAME}/$(curl -s http://ip.cloudvps.nl): Other backup job still running, more than 24 hours." "${recipient}" <<MAIL
 
 Dear user,
 
@@ -49,7 +49,7 @@ Should this process hang for 24 hours as well, you will receive this message aga
 
 Your files have not been backupped during this session.
 
-This is server $(curl -s http://ip.raymii.org). You are using CloudVPS Boss ${VERSION}
+This is server $(curl -s http://ip.cloudvps.nl). You are using CloudVPS Boss ${VERSION}
 to backup files to the CloudVPS Object Store.
 
 Kind regards,
@@ -72,7 +72,7 @@ less_than_24hour_mail() {
         command_exists "${COMMAND}"
     done
 
-    mail -s "[CLOUDVPS BOSS] ${HOSTNAME}/$(curl -s http://ip.raymii.org): Other backupjob still running, less than 24 hours." "${recipient}" <<MAIL
+    mail -s "[CLOUDVPS BOSS] ${HOSTNAME}/$(curl -s http://ip.cloudvps.nl): Other backupjob still running, less than 24 hours." "${recipient}" <<MAIL
 
 Dear user,
 
@@ -89,7 +89,7 @@ Currently, there is no intervention needed from your side, CloudVPS Boss has alr
 
 Your files have not been backupped during this session.
 
-This is server $(curl -s http://ip.raymii.org). You are using CloudVPS Boss ${VERSION}
+This is server $(curl -s http://ip.cloudvps.nl). You are using CloudVPS Boss ${VERSION}
 to backup files to the CloudVPS Object Store.
 
 Kind regards,

--- a/cloudvps-boss/pre-backup.d/15-mysql_backup.sh
+++ b/cloudvps-boss/pre-backup.d/15-mysql_backup.sh
@@ -44,7 +44,7 @@ failed_mail() {
         command_exists "${COMMAND}"
     done
 
-    mail -s "[CLOUDVPS BOSS] MySQL backup failed on ${HOSTNAME}/$(curl -s http://ip.raymii.org)." "${recipient}" <<MAIL
+    mail -s "[CLOUDVPS BOSS] MySQL backup failed on ${HOSTNAME}/$(curl -s http://ip.cloudvps.nl)." "${recipient}" <<MAIL
 
 Dear user,
 
@@ -59,7 +59,7 @@ If you've corrected the credentials error and you keep receiving this message, t
 
 Your MySQL databases have not been backupped during this session.
 
-This is server $(curl -s http://ip.raymii.org). You are using CloudVPS Boss ${VERSION}
+This is server $(curl -s http://ip.cloudvps.nl). You are using CloudVPS Boss ${VERSION}
 to backup files to the CloudVPS Object Store.
 
 Kind regards,


### PR DESCRIPTION
Fixed the CURL request to fetch the IP address. The host used does no longer exists. This has been changed to the correct host so that the IP address can be fetched and is present in the error email messages. 