### PR TITLE
Remove syntax error from cron definition

### DIFF
--- a/cloudvps-boss/cloudvps-boss.cron
+++ b/cloudvps-boss/cloudvps-boss.cron
@@ -29,4 +29,3 @@ RANDM RANDH * * * root /usr/local/bin/cloudvps-boss
 
 # CloudVPS Boss Update
 0 1 1 * * root /usr/local/bin/cloudvps-boss-update
-=======


### PR DESCRIPTION
Probably a leftover from an earlier merge conflict.