### PR TITLE
Add support for Debian 10 / Ubuntu 20.

### DIFF
--- a/install_duplicity.sh
+++ b/install_duplicity.sh
@@ -348,6 +348,33 @@ EOF
 
 }
 
+install_duplicity_debian_10() {
+    APT_PACKAGES=(
+      util-linux
+      wget
+      dialog
+      libc6
+      git-core
+      python3-keystoneclient
+      python3-swiftclient
+      librsync2
+      duplicity
+    )
+
+    APT_UPDATE="$(apt-get -qq -y --force-yes update > /dev/null 2>&1)"
+    if [[ "$?" -ne 0 ]]; then
+        lerror "'apt-get update' failed."
+        exit 1
+    fi
+
+    APT_INSTALL="$(apt-get -qq -y --force-yes install ${APT_PACKAGES[*]} 2>&1)"
+    if [[ "$?" -ne 0 ]]; then
+        lerror "'apt-get install ${APT_PACKAGES[*]}' failed."
+        exit 1
+    fi
+}
+
+
 install_duplicity_centos_6() {
 
     YUM_CLEAN="$(yum -q -y clean all 2>&1)"
@@ -622,6 +649,10 @@ case "${DISTRO_NAME}" in
 
     "Debian")
         case "${DISTRO_VERSION}" in
+            10)
+                lecho "Debian 10"
+                install_duplicity_debian_10
+                ;;
             9)
                 lecho "Debian 9"
                 install_duplicity_debian_8
@@ -642,8 +673,16 @@ case "${DISTRO_NAME}" in
     ;;
     "Ubuntu")
         # ubuntu has keystoneclient and swiftclient in the repo's.
-        lecho "Ubuntu ${DISTRO_VERSION}"
-        install_duplicity_debian_8
+        case "${DISTRO_VERSION}" in
+            20.*)
+                lecho "Ubuntu ${DISTRO_VERSION}"
+                install_duplicity_debian_10
+		;;
+            *)
+                lecho "Ubuntu ${DISTRO_VERSION}"
+                install_duplicity_debian_8
+                ;;
+        esac
     ;;
     "CentOS")
         case "${DISTRO_VERSION}" in


### PR DESCRIPTION
Ubuntu 20 and Debian 10 have switched to using python3 by default.
Therefore cloudvps-boss as it is packaged now does not work correctly on these distro's.
By switching to duplicity packaged by Ubuntu upstream cloudvps-boss seems to work as intended on Ubuntu 20.04.

Other than duplicity 0.7.17 being incompatible with python3 there's several packages that have been renamed between Ubuntu 18.04 / Debian 9 and Ubuntu 20.04 / Debian 10.

Note: only Ubuntu 20.04 has been (inextensively) tested, I'm assuming Debian 10 should work equally well.
I'm not aware of the reason for duplicity 0.7.17 to be compiled from a custom CloudVPS source [download](https://download.cloudvps.com/cloudvps-boss/duplicity/duplicity-0.7.17.tar.gz).
If there's pressing reasons behind that decision, I'd be glad to hear.